### PR TITLE
Add `Update URI` plugin header

### DIFF
--- a/lib/templates/innerblocks/plugin.php.mustache
+++ b/lib/templates/innerblocks/plugin.php.mustache
@@ -8,6 +8,7 @@
  * Author:      Dekode Interaktiv
  * Version:     1.0.0
  * AuthorURI:   https://dekode.no/
+ * Update URI:  false
  *
  * @package     {{namespace}}
  */

--- a/lib/templates/plain/plugin.php.mustache
+++ b/lib/templates/plain/plugin.php.mustache
@@ -8,6 +8,7 @@
  * Author:      Dekode Interaktiv
  * Version:     1.0.0
  * AuthorURI:   https://dekode.no/
+ * Update URI:  false
  *
  * @package     {{namespace}}
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dekode/create-project-base-block",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Generates PHP, JS and CSS code for registering a block for a WordPress plugin.",
 	"author": "Dekode Interaktiv AS",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
The `Plugin URI` allows us to control update-offerings for plugins from WordPress.org.

See https://make.wordpress.org/core/2021/06/29/introducing-update-uri-plugin-header-in-wordpress-5-8/